### PR TITLE
for dataAtom, re-create observer when options change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- for dataAtom, re-create observer when options change #5
 
 ## [0.1.0] - 2022-09-24
 ### Added

--- a/src/common.ts
+++ b/src/common.ts
@@ -103,9 +103,13 @@ export const createAtoms = <
         return { unsubscribe }
       },
     }
-    const resultAtom = atomWithObservable(() => observable, {
-      initialValue: observer.getCurrentResult().data,
-    })
+    const currentResult = observer.getCurrentResult()
+    const options =
+      (currentResult.isSuccess && currentResult.data !== undefined) ||
+      (currentResult.isError && !isCancelledError(currentResult.error))
+        ? { initialValue: currentResult }
+        : {}
+    const resultAtom = atomWithObservable(() => observable, options)
     return resultAtom
   })
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -83,23 +83,9 @@ export const createAtoms = <
     }
   )
 
-  const pendingCallbacksCache = new WeakMap<
-    Observer,
-    Set<(result: Result) => void>
-  >()
-  const getPendingCallbacks = (observer: Observer) => {
-    let pendingCallbacks = pendingCallbacksCache.get(observer)
-    if (!pendingCallbacks) {
-      pendingCallbacks = new Set()
-      pendingCallbacksCache.set(observer, pendingCallbacks)
-    }
-    return pendingCallbacks
-  }
-
   const baseDataAtom = atom((get) => {
     getOptions(get) // re-create observable when options change
     const observer = get(observerAtom)
-    const pendingCallbacks = getPendingCallbacks(observer)
     const observable = {
       subscribe: (
         arg: { next: (result: Result) => void } | ((result: Result) => void)
@@ -110,15 +96,8 @@ export const createAtoms = <
             (result.isError && !isCancelledError(result.error))
           ) {
             ;(typeof arg === 'function' ? arg : arg.next)(result)
-            pendingCallbacks.forEach((cb) => {
-              if (cb !== callback) {
-                cb(result)
-              }
-            })
-            pendingCallbacks.clear()
           }
         }
-        pendingCallbacks.add(callback)
         const unsubscribe = observer.subscribe(callback)
         callback(observer.getCurrentResult())
         return { unsubscribe }

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,7 +15,6 @@ export const createAtoms = <
     setOptions(options: Options): void
     getCurrentResult(): Result
     subscribe(callback: (result: Result) => void): () => void
-    destroy?(): void
   },
   Action
 >(
@@ -39,14 +38,11 @@ export const createAtoms = <
     const observerCache = get(observerCacheAtom)
     let observer = observerCache.get(queryClient)
     if (observer) {
-      if (observer.destroy) {
-        observer.destroy()
-        observer.setOptions(options)
-      } else {
-        Promise.resolve().then(() => {
-          ;(observer as Observer).setOptions(options)
-        })
-      }
+      // Needs to delay because this can be called in render
+      // FIXME Is there a better way?
+      Promise.resolve().then(() => {
+        ;(observer as Observer).setOptions(options)
+      })
     } else {
       observer = createObserver(queryClient, options)
       observerCache.set(queryClient, observer)

--- a/src/common.ts
+++ b/src/common.ts
@@ -103,7 +103,9 @@ export const createAtoms = <
         return { unsubscribe }
       },
     }
-    const resultAtom = atomWithObservable(() => observable)
+    const resultAtom = atomWithObservable(() => observable, {
+      initialValue: observer.getCurrentResult().data,
+    })
     return resultAtom
   })
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,6 +15,7 @@ export const createAtoms = <
     setOptions(options: Options): void
     getCurrentResult(): Result
     subscribe(callback: (result: Result) => void): () => void
+    destroy?(): void
   },
   Action
 >(
@@ -38,7 +39,14 @@ export const createAtoms = <
     const observerCache = get(observerCacheAtom)
     let observer = observerCache.get(queryClient)
     if (observer) {
-      observer.setOptions(options)
+      if (observer.destroy) {
+        observer.destroy()
+        observer.setOptions(options)
+      } else {
+        Promise.resolve().then(() => {
+          ;(observer as Observer).setOptions(options)
+        })
+      }
     } else {
       observer = createObserver(queryClient, options)
       observerCache.set(queryClient, observer)

--- a/src/common.ts
+++ b/src/common.ts
@@ -83,7 +83,8 @@ export const createAtoms = <
     }
   )
 
-  const baseDataAtom = atomWithObservable((get) => {
+  const baseDataAtom = atom((get) => {
+    getOptions(get) // re-create observable when options change
     const observer = get(observerAtom)
     const observable = {
       subscribe: (
@@ -102,16 +103,18 @@ export const createAtoms = <
         return { unsubscribe }
       },
     }
-    return observable
+    const resultAtom = atomWithObservable(() => observable)
+    return resultAtom
   })
 
   const dataAtom = atom(
     (get) => {
-      const baseData = get(baseDataAtom)
-      if (baseData.error) {
-        throw baseData.error
+      const resultAtom = get(baseDataAtom)
+      const result = get(resultAtom)
+      if (result.error) {
+        throw result.error
       }
-      return baseData.data
+      return result.data
     },
     (_get, set, action: Action) => set(statusAtom, action)
   )

--- a/src/common.ts
+++ b/src/common.ts
@@ -38,7 +38,8 @@ export const createAtoms = <
     const observerCache = get(observerCacheAtom)
     let observer = observerCache.get(queryClient)
     if (observer) {
-      // Needs to delay because this can be called in render
+      // Needs to delay because this is called in render
+      // and `setOptions` notifies listeners.
       // FIXME Is there a better way?
       Promise.resolve().then(() => {
         ;(observer as Observer).setOptions(options)


### PR DESCRIPTION
does this work better? dataAtom can be opinionated as we now have statusAtom.

also add a workaround for `setOptions`.